### PR TITLE
chore: fixing typo in the image name

### DIFF
--- a/charts/s3-file-server/values.yaml
+++ b/charts/s3-file-server/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/your-username/s3-file-server
+  repository: ghcr.io/sergeychernyshov-code/s3-file-server
   tag: "0.1.0"
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
chore: fixing typo in the image name