### PR TITLE
debug: adding specific to nginx ingress annotations to the helm chart

### DIFF
--- a/charts/s3-file-server/templates/ingress.yaml
+++ b/charts/s3-file-server/templates/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
+  ingressClassName: nginx
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .host }}

--- a/charts/s3-file-server/values.yaml
+++ b/charts/s3-file-server/values.yaml
@@ -12,7 +12,7 @@ service:
 ingress:
   enabled: true
   className: nginx
-  annotations: {}
+  annotations: { "nginx.ingress.kubernetes.io/rewrite-target: /" }
   hosts:
     - host: s3-file-server.local
       paths:


### PR DESCRIPTION
debug: adding specific to nginx ingress annotations to the helm chart