### PR TITLE
fix: simplifying Helm Chart Ingress template

### DIFF
--- a/charts/s3-file-server/templates/ingress.yaml
+++ b/charts/s3-file-server/templates/ingress.yaml
@@ -8,17 +8,17 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    {{- range .Values.ingress.hosts }}
     - http:
         paths:
+          {{- range .Values.ingress.hosts }}
           {{- range .paths }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "s3-file-server.fullname" . }}
+                name: {{ include "s3-file-server.fullname" $ }}
                 port:
                   number: 80
           {{- end }}
-    {{- end }}
+          {{- end }}
 {{- end }}

--- a/charts/s3-file-server/values.yaml
+++ b/charts/s3-file-server/values.yaml
@@ -12,9 +12,7 @@ service:
 ingress:
   enabled: true
   className: nginx
-  annotations: { 
-    nginx.ingress.kubernetes.io/rewrite-target: '/'
-  }
+  annotations: {}
   hosts:
       paths:
         - path: /


### PR DESCRIPTION
since we want to allow all Host headers, removing appropriate section from the template